### PR TITLE
fix DrawBBE alphalevel

### DIFF
--- a/Injection/Core/RoCodeBind.cpp
+++ b/Injection/Core/RoCodeBind.cpp
@@ -995,7 +995,7 @@ void CRoCodeBind::DrawBBE(IDirect3DDevice7* d3ddevice)
 					}
 					if (pCell->flag){
 						if (deadcell){
-							color = 0x30ff00ff;
+							color = 0x00ff00ff;
 						}
 					}
 


### PR DESCRIPTION
deadcell color においてalpha lvの初期値を0にしスライドバーでの変更をそのまま反映するように修正
